### PR TITLE
Refactor kraken_losers to use CLI arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+kraken_top_losers.csv

--- a/README.md
+++ b/README.md
@@ -23,8 +23,12 @@ A Python-based cryptocurrency quant research toolkit and pipeline.
 
 - **Top Losers Script:**
     ```sh
-    python kraken_losers.py
+    python kraken_losers.py [--top-n TOP_N] [--min-volume MIN_VOLUME] [--include-stables]
     ```
+    - `--top-n`: number of top losers to display/save (default: 20)
+    - `--min-volume`: minimum 24h volume to include (default: 1000)
+    - `--include-stables`: include known stablecoins (USDT, USDC, DAI) in results
+
 Outputs a CSV and prints top 24h price drops to the terminal.
 
 ## Contributing

--- a/kraken_losers.py
+++ b/kraken_losers.py
@@ -6,20 +6,23 @@ retrieves 24-hour price data, computes % change, and
 outputs the top N "losers" (biggest price drops).
 """
 
+import argparse
 import requests
 import pandas as pd
 
-# --- Configurable parameters ---
-TOP_N = 20        # Number of top losers to display/save
-MIN_VOLUME = 1000 # Minimum 24h volume to include (adjust as needed)
-EXCLUDE_STABLES = True  # Exclude known stables (rudimentary, improve as needed)
 
 def get_usd_pairs():
     """Get all USD trading pairs from Kraken"""
     url = "https://api.kraken.com/0/public/AssetPairs"
-    pairs = requests.get(url).json()['result']
-    usd_pairs = [k for k, v in pairs.items() if v.get('wsname', '').endswith('USD')]
+    try:
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+    except requests.RequestException as exc:
+        raise SystemExit(f"Error fetching asset pairs: {exc}")
+    pairs = resp.json()["result"]
+    usd_pairs = [k for k, v in pairs.items() if v.get("wsname", "").endswith("USD")]
     return usd_pairs
+
 
 def fetch_ticker_data(pairs):
     """Get ticker info for a list of pairs (up to 100 at a time)"""
@@ -27,12 +30,40 @@ def fetch_ticker_data(pairs):
     chunk_size = 100
     all_data = {}
     for i in range(0, len(pairs), chunk_size):
-        chunk = ",".join(pairs[i:i+chunk_size])
-        resp = requests.get(url, params={"pair": chunk}).json()['result']
-        all_data.update(resp)
+        chunk = ",".join(pairs[i : i + chunk_size])
+        try:
+            resp = requests.get(url, params={"pair": chunk}, timeout=10)
+            resp.raise_for_status()
+        except requests.RequestException as exc:
+            raise SystemExit(f"Error fetching ticker data: {exc}")
+        all_data.update(resp.json()["result"])
     return all_data
 
+
 def main():
+    parser = argparse.ArgumentParser(
+        description="Fetch top 24h losers (biggest price drops) on Kraken.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--top-n",
+        type=int,
+        default=20,
+        help="Number of top losers to display/save",
+    )
+    parser.add_argument(
+        "--min-volume",
+        type=float,
+        default=1000,
+        help="Minimum 24h volume to include",
+    )
+    parser.add_argument(
+        "--include-stables",
+        action="store_true",
+        help="Include known stablecoins in results",
+    )
+    args = parser.parse_args()
+
     usd_pairs = get_usd_pairs()
     print(f"Found {len(usd_pairs)} USD pairs on Kraken.")
 
@@ -40,34 +71,39 @@ def main():
     rows = []
     for sym, vals in ticker.items():
         try:
-            open_ = float(vals['o'])
-            last = float(vals['c'][0])
-            volume = float(vals['v'][1])  # 24h rolling volume
+            open_ = float(vals["o"])
+            last = float(vals["c"][0])
+            volume = float(vals["v"][1])  # 24h rolling volume
             pct_change = 100 * (last - open_) / open_
-            rows.append({
-                "symbol": sym,
-                "open": open_,
-                "last": last,
-                "pct_change": pct_change,
-                "volume": volume
-            })
+            rows.append(
+                {
+                    "symbol": sym,
+                    "open": open_,
+                    "last": last,
+                    "pct_change": pct_change,
+                    "volume": volume,
+                }
+            )
         except Exception:
             continue
 
     df = pd.DataFrame(rows)
-    if EXCLUDE_STABLES:
-        # Quick filter for stables (improve as needed)
-        stables = ['USDT', 'USDC', 'USD', 'DAI']
-        df = df[~df['symbol'].str.contains('|'.join(stables))]
-    df = df[df['volume'] >= MIN_VOLUME]
-    df = df.sort_values('pct_change').reset_index(drop=True)
+    if not args.include_stables:
+        # Quick filter for common USD stablecoins by checking the base asset
+        stables = {"USDT", "USDC", "DAI"}
+        base_assets = df["symbol"].str.slice(stop=-3)
+        df = df[~base_assets.isin(stables)]
+    df = df[df["volume"] >= args.min_volume]
+    df = df.sort_values("pct_change").reset_index(drop=True)
 
-    print(f"\nTop {TOP_N} 24h losers (by %):")
-    print(df[['symbol', 'pct_change', 'volume']].head(TOP_N))
+    print(f"\nTop {args.top_n} 24h losers (by %):")
+    print(df[["symbol", "pct_change", "volume"]].head(args.top_n))
 
     # Optionally, export to CSV
-    df.head(TOP_N).to_csv('kraken_top_losers.csv', index=False)
+    df.head(args.top_n).to_csv("kraken_top_losers.csv", index=False)
     print("\nExported to kraken_top_losers.csv.")
+
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- replace global config constants in `kraken_losers.py` with argparse options
- document and expose CLI flags in README usage section
- add timeouts and graceful error handling to Kraken API requests
- fix stablecoin filter to avoid excluding all USD pairs and ignore generated CSV output

## Testing
- `python kraken_losers.py --help`
- `python kraken_losers.py --top-n 1 --min-volume 0`


------
https://chatgpt.com/codex/tasks/task_e_68946e0e9bb0832ba2e61b1c88ad67bb