### PR TITLE
Improve Kraken API error handling

### DIFF
--- a/tests/test_kraken_losers.py
+++ b/tests/test_kraken_losers.py
@@ -1,5 +1,12 @@
 import pandas as pd
-from kraken_losers import exclude_stable_pairs
+import pytest
+import requests
+from kraken_losers import (
+    KrakenAPIError,
+    exclude_stable_pairs,
+    fetch_ticker_data,
+    get_usd_pairs,
+)
 
 
 def test_exclude_stable_pairs_filters_only_stables():
@@ -11,3 +18,30 @@ def test_exclude_stable_pairs_filters_only_stables():
     filtered = exclude_stable_pairs(df)
 
     assert set(filtered["symbol"]) == {"BTCUSD", "ETHUSD"}
+
+
+def test_get_usd_pairs_raises_on_request_error(monkeypatch):
+    def fake_get(*args, **kwargs):
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    with pytest.raises(KrakenAPIError):
+        get_usd_pairs()
+
+
+def test_fetch_ticker_data_raises_on_api_error(monkeypatch):
+    class FakeResp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"error": ["EQuery:Unknown asset pair"]}
+
+    def fake_get(*args, **kwargs):
+        return FakeResp()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    with pytest.raises(KrakenAPIError):
+        fetch_ticker_data(["BTCUSD"])


### PR DESCRIPTION
## Summary
- add `KrakenAPIError` for consistent HTTP error handling
- validate API responses and log malformed ticker rows
- test error cases for USD pairs and ticker retrieval

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689486fb3824832ba83e8bbdffe38bd5