### PR TITLE
Use SQLAlchemy engine and add leaderboard summary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests
 pytest
 mysql-connector-python
 hdbscan
+sqlalchemy


### PR DESCRIPTION
## Summary
- Switch database access to SQLAlchemy engine to avoid pandas read_sql warnings.
- Prompt user for top N leaderboard size with default of 20 and generate JSON summary of results.
- Add SQLAlchemy dependency.

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895943af544832b8a10d2a866cd3eb4